### PR TITLE
Recording leave cleanup

### DIFF
--- a/src/app/components/PartialLeavePopover.tsx
+++ b/src/app/components/PartialLeavePopover.tsx
@@ -15,7 +15,7 @@ export default class PartialLeavePopover extends React.Component<PartialLeavePop
         const { 
             leave = {}, 
             placement = 'left',
-            icon = <Glyphicon style={{ color: 'darkorange', zIndex: 2000}} glyph="alert" />
+            icon = <Glyphicon style={{ color: 'darkorange', zIndex: 1000}} glyph="alert" />
         } = this.props;
 
         return (

--- a/src/app/containers/LeaveSubCodeDisplay.tsx
+++ b/src/app/containers/LeaveSubCodeDisplay.tsx
@@ -11,7 +11,7 @@ interface LeaveSubCodeDisplayStateProps {
 }
 
 interface LeaveSubCodeDisplayProps {
-    subCode: string;
+    subCode?: string;
 }
 
 class LeaveSubCodeDisplay extends React.PureComponent<
@@ -28,9 +28,9 @@ class LeaveSubCodeDisplay extends React.PureComponent<
 
 // tslint:disable-next-line:max-line-length
 export default connect<LeaveSubCodeDisplayStateProps, {}, LeaveSubCodeDisplayProps, RootState>(
-    (state: RootState, props) => {
+    (state: RootState, {subCode}) => {
         return {
-            leaveSubCode: allLeavesSubCodeMap(state)[props.subCode]
+            leaveSubCode: subCode ? allLeavesSubCodeMap(state)[subCode] : undefined
         };
     },
     {}

--- a/src/app/containers/ScheduleSummary.tsx
+++ b/src/app/containers/ScheduleSummary.tsx
@@ -89,6 +89,8 @@ class ConnectedScheduleSummary extends React.Component<ConnectedScheduleSummaryP
             .filter(l => doTimeRangesOverlap(
                 { startTime: moment(l.startDate).toISOString(), endTime: moment(l.endDate).toISOString() },
                 { startTime: moment(visibleTimeStart).toISOString(), endTime: moment(visibleTimeEnd).toISOString() })
+                ||
+                moment(l.endDate).isSame(moment(visibleTimeStart))
             );
         const partialDayLeavesForWeek = partialDayLeaves
             .filter(l => moment(l.startDate).isBetween(visibleTimeStart, visibleTimeEnd, 'days', '[]'));

--- a/src/app/containers/SheriffLeaveDisplay.tsx
+++ b/src/app/containers/SheriffLeaveDisplay.tsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import LeaveDisplay, { LeavesDisplayProps } from '../components/LeavesDisplay';
 import { IdType } from '../api';
-import { getAllSheriffFullDayLeaves, getAllSheriffPartialLeaves } from '../modules/leaves/selectors';
+import { getSheriffFullDayPersonalLeaves, getSheriffPartialPersonalLeaves } from '../modules/leaves/selectors';
 import { RootState } from '../store';
 
 export interface SheriffLeaveDisplayProps {
@@ -17,8 +17,8 @@ export default connect<SheriffLeaveDisplayStateProps, SheriffLeaveDisplayDispatc
     (
     (state, { sheriffId }) => {
         return {
-            fullDays: getAllSheriffFullDayLeaves(sheriffId)(state),
-            partialDays: getAllSheriffPartialLeaves(sheriffId)(state) 
+            fullDays: getSheriffFullDayPersonalLeaves(sheriffId)(state),
+            partialDays: getSheriffPartialPersonalLeaves(sheriffId)(state) 
         };
     },
     {

--- a/src/app/containers/SheriffProfilePluginLeaves/LeavesFieldTable.tsx
+++ b/src/app/containers/SheriffProfilePluginLeaves/LeavesFieldTable.tsx
@@ -11,7 +11,8 @@ import PersonalLeaveSubCodeSelector from '../PersonalLeaveSubCodeSelector';
 import CancelLeaveButton from '../CancelLeaveButton';
 import LeaveCancelledPopover from '../../components/LeaveCancelledPopover';
 import TimePickerField from '../../components/FormElements/TimePickerField';
-import { fromTimeString, toTimeString } from 'jag-shuber-api/dist/client';
+import { fromTimeString, toTimeString } from '../../../../node_modules/jag-shuber-api/dist/client';
+import LeaveSubCodeDisplay from '../LeaveSubCodeDisplay';
 
 export interface ColumnRendererProps {
     index: number;
@@ -73,9 +74,7 @@ export default class LeavesFieldTable extends React.Component<LeavesFieldTablePr
             />
         ),
         CanceledRender: ({ leave }) => (
-            <span>
-                {leave.leaveSubCode}
-            </span>
+            <LeaveSubCodeDisplay subCode={leave.leaveSubCode}/>
         )
     };
 

--- a/src/app/containers/SheriffProfilePluginLeaves/SheriffProfilePluginLeaves.tsx
+++ b/src/app/containers/SheriffProfilePluginLeaves/SheriffProfilePluginLeaves.tsx
@@ -14,8 +14,8 @@ import { Dispatch } from 'redux';
 import { getLeaves, createOrUpdateLeaves } from '../../modules/leaves/actions';
 import { RootState } from '../../store';
 import {
-    getAllSheriffFullDayLeaves,
-    getAllSheriffPartialLeaves,
+    getSheriffFullDayPersonalLeaves,
+    getSheriffPartialPersonalLeaves
 } from '../../modules/leaves/selectors';
 import LeavesDisplay from '../../components/LeavesDisplay';
 import * as Validators from '../../infrastructure/Validators';
@@ -111,8 +111,8 @@ export default class SheriffProfilePluginLeaves extends SheriffProfileSectionPlu
     
     getData(sheriffId: IdType, state: RootState) {
         return {
-            partialDay: getAllSheriffPartialLeaves(sheriffId)(state),
-            fullDay: getAllSheriffFullDayLeaves(sheriffId)(state)
+            partialDay: getSheriffPartialPersonalLeaves(sheriffId)(state),
+            fullDay: getSheriffFullDayPersonalLeaves(sheriffId)(state)
         };
     }
 

--- a/src/app/modules/leaves/selectors.ts
+++ b/src/app/modules/leaves/selectors.ts
@@ -9,14 +9,34 @@ import {
 } from '../../api/Api';
 import mapToArray from '../../infrastructure/mapToArray';
 import arrayToMap from '../../infrastructure/arrayToMap';
+import moment from 'moment';
 
 export const cancelReasonCodesMap = leaveRequests.leaveCancelCodeMapRequest.getData;
+
 export const allLeaves = createSelector(
     leaveRequests.leaveMapRequest.getData,
-    (map) => mapToArray(map)
+    (map) => {
+        const leaveMap = mapToArray(map)
+            .filter(l => moment(l.startDate).isSameOrAfter(moment().subtract(1, 'year'), 'day'));
+        return leaveMap
         .sort((a, b) => `${a.startDate}`
-            .localeCompare(`${b.startDate}`))
+            .localeCompare(`${b.startDate}`));
+    }
 );
+
+export const getAllPersonaLeaves = (state: RootState) => {
+    if (state) {
+        return allLeaves(state).filter(l => l.leaveCode === LEAVE_CODE_PERSONAL);
+    }
+    return undefined;
+};
+
+export const getAllTrainingLeaves = (state: RootState) => {
+    if (state) {
+        return allLeaves(state).filter(l => l.leaveCode === LEAVE_CODE_TRAINING);
+    }
+    return undefined;
+};
 
 export const getLeave = (id?: IdType) => (state: RootState) => {
     if (state && id != null) {
@@ -57,6 +77,24 @@ export const getAllSheriffPartialLeaves = (sheriffId?: IdType) => (state: RootSt
 export const getAllSheriffFullDayLeaves = (sheriffId?: IdType) => (state: RootState) => {
     if (state && sheriffId != null) {
         return getFullDayLeaves(state).filter(l => l.sheriffId === sheriffId);
+    }
+    return [];
+};
+
+export const getSheriffPartialPersonalLeaves = (sheriffId?: IdType) => (state: RootState) => {
+    if (state && sheriffId != null) {
+        return getPartialDayLeaves(state)
+            .filter(l => l.sheriffId === sheriffId)
+            .filter(sl => sl.leaveCode === LEAVE_CODE_PERSONAL);
+    }
+    return [];
+};
+
+export const getSheriffFullDayPersonalLeaves = (sheriffId?: IdType) => (state: RootState) => {
+    if (state && sheriffId != null) {
+        return getFullDayLeaves(state)
+            .filter(l => l.sheriffId === sheriffId)
+            .filter(sl => sl.leaveCode === LEAVE_CODE_PERSONAL);
     }
     return [];
 };

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -24,7 +24,8 @@ import { UserState, registerReducer as registerUserReducer } from './modules/use
 import { LeaveModuleState, registerReducer as registerLeavesReducer } from './modules/leaves/reducer';
 import {
     getLeaveCancelCodes,
-    getLeaveSubCodes
+    getLeaveSubCodes,
+    getLeaves
 } from './modules/leaves/actions';
 
 export interface ThunkExtra {
@@ -54,7 +55,8 @@ const initialActions: any[] = [
     getSheriffRankCodes,
     getShifts,
     getLeaveCancelCodes,
-    getLeaveSubCodes
+    getLeaveSubCodes,
+    getLeaves
 ];
 
 const reducers = {


### PR DESCRIPTION
- ensure leaves are loaded when app loads 
- fixed z-index of on-leave popover
- filter leaves to only show those that have a start date within the last year or in the future
- bug fix, so that leaves that end on a Monday show appropriately in the manage schedule page