### PR TITLE
Fix s2i build process

### DIFF
--- a/docker/manage
+++ b/docker/manage
@@ -131,6 +131,7 @@ build-frontend() {
 
   echoGreen "\n\nBuilding frontend artifacts ...\n"
   ${S2I_EXE} build \
+    --copy \
     -s 'file://../.s2i/bin' \
     '../' \
     'yarn-builder' \


### PR DESCRIPTION
- Add `--copy` to s2i builds so they build off the working copy changes rather that the latest commit.

Signed-off-by: Wade Barnes <wade.barnes@shaw.ca>